### PR TITLE
Round values in format_forecast()

### DIFF
--- a/R/format_forecast.R
+++ b/R/format_forecast.R
@@ -84,6 +84,6 @@ format_forecast <- function(forecasts,
     forecasts_format[, c("horizon", "submission_date", "location_name") := NULL]
 
   forecasts_format <- 
-    forecasts_format[, value := ifelse(value > max_value, max_value, value)]
+    forecasts_format[, value := ifelse(value > max_value, round(max_value), round(value))]
   return(forecasts_format)
 }


### PR DESCRIPTION
The Euro hub has updated to accept only integer values - [see here](https://github.com/epiforecasts/covid19-forecast-hub-europe/issues/537). 

This PR updates `format_forecast()` so that the formatted saved forecasts have integer values.

I think this PR should do the trick for the epiforecasts euro hub submission, but I haven't spent much time with this repo or know where else these forecasts are being used - so please check.